### PR TITLE
Update ESLint to version 9 with flat config

### DIFF
--- a/bin/development-template.ts
+++ b/bin/development-template.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import * as dotenv from "dotenv"; // see https://github.com/motdotla/dotenv#how-do-i-use-dotenv-with-import
-import { randomBytes } from "crypto";
 import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { DevelopmentTemplateStack } from "../lib/development-template-stack";

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,25 +1,80 @@
-module.exorts = {
-  root: true,
-  env: {
-    node: true,
-    jest: true,
-    browser: true,
-  },
-  extends: ["plugin:@typescript-eslint/recommended", "prettier"],
-  parser: "@typescript-eslint/parser",
-  parserOptions: {
-    project: "./tsconfig.json",
-    sourceType: "module",
-  },
-  plugins: ["@typescript-eslint/eslint-plugin", "import"],
-  rules: {
-    "no-console": 0,
-    semi: 0,
-    "@typescript-eslint/no-explicit-any": 0,
-  },
-  settings: {
-    "import/parsers": {
-      "@typescript-eslint/parser": [".ts", ".tsx"],
+// @ts-check
+const eslint = require("@eslint/js");
+const tseslint = require("typescript-eslint");
+const prettierConfig = require("eslint-config-prettier");
+
+module.exports = tseslint.config(
+  // Base recommended configs
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+
+  // Prettier config to disable conflicting rules
+  prettierConfig,
+
+  // TypeScript-specific configuration
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: "./tsconfig.json",
+        sourceType: "module",
+      },
+      globals: {
+        // Node.js globals
+        process: "readonly",
+        __dirname: "readonly",
+        __filename: "readonly",
+        module: "readonly",
+        require: "readonly",
+        console: "readonly",
+        Buffer: "readonly",
+        // Jest globals
+        describe: "readonly",
+        test: "readonly",
+        it: "readonly",
+        expect: "readonly",
+        beforeEach: "readonly",
+        afterEach: "readonly",
+        beforeAll: "readonly",
+        afterAll: "readonly",
+        jest: "readonly",
+      },
+    },
+    rules: {
+      "no-console": 0,
+      semi: 0,
+      "@typescript-eslint/no-explicit-any": 0,
     },
   },
-};
+
+  // JavaScript files configuration (including config files)
+  {
+    files: ["**/*.js", "**/*.mjs", "**/*.cjs"],
+    languageOptions: {
+      sourceType: "commonjs",
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        __filename: "readonly",
+        module: "readonly",
+        require: "readonly",
+        console: "readonly",
+      },
+    },
+    rules: {
+      "no-console": 0,
+      semi: 0,
+      "@typescript-eslint/no-require-imports": 0,
+    },
+  },
+
+  // Ignore patterns (replaces .eslintignore)
+  {
+    ignores: [
+      "node_modules/**",
+      "cdk.out/**",
+      "*.d.ts",
+    ],
+  }
+);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,9 @@
 // @ts-check
-const eslint = require("@eslint/js");
-const tseslint = require("typescript-eslint");
-const prettierConfig = require("eslint-config-prettier");
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+import prettierConfig from "eslint-config-prettier";
 
-module.exports = tseslint.config(
+export default tseslint.config(
   // Base recommended configs
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
@@ -65,7 +65,6 @@ module.exports = tseslint.config(
     rules: {
       "no-console": 0,
       semi: 0,
-      "@typescript-eslint/no-require-imports": 0,
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
-    "cdk:deploy": "cdk deploy"
+    "cdk:deploy": "cdk deploy",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.1",
     "@typescript-eslint/eslint-plugin": "8.46.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
         specifier: ^0.5.21
         version: 0.5.21
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.1
+        version: 9.39.1
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -71,6 +74,9 @@ packages:
   /@aws-cdk/cloud-assembly-schema@48.18.0:
     resolution: {integrity: sha512-KJHmkji59QboUIytK/imIY/ajt/r7OOXdyvZz25e0jssreyyxx9HUswZpcB0BM/9ZkVI7IdzYlotWe6opXdapg==}
     engines: {node: '>= 18.0.0'}
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.7.3
     dev: false
     bundledDependencies:
       - jsonschema
@@ -2673,6 +2679,10 @@ packages:
     hasBin: true
     dev: true
 
+  /jsonschema@1.4.1:
+    resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
+    dev: false
+
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
@@ -3028,7 +3038,6 @@ packages:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: true
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}


### PR DESCRIPTION
- Convert eslint.config.js from .eslintrc format to flat config
- Add @eslint/js dependency for flat config support
- Configure separate rules for TypeScript and JavaScript files
- Add lint and lint:fix scripts to package.json
- Remove unused randomBytes import from bin/development-template.ts
- Add proper file-specific configurations for .ts and .js files